### PR TITLE
Update sbt-scoverage from 2.0.0 to 2.0.4 (#94)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,9 @@
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.4")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)


### PR DESCRIPTION
* Update sbt-scoverage from 2.0.0 to 2.0.4

* Fix binary incompatible issue

Co-authored-by: Anand Singh <4903911+anand-singh@users.noreply.github.com>